### PR TITLE
Refactor slide menu usage

### DIFF
--- a/components/SlideMenu.swift
+++ b/components/SlideMenu.swift
@@ -175,7 +175,8 @@ struct MainView: View {
 		ZStack(alignment: .topLeading) {
 			// Your main content here
 
-			Spring(isShowing: $menuViewModel.isShowing)
+                        // Spring menu button disabled for consistency
+//                      Spring(isShowing: $menuViewModel.isShowing)
 
 			if menuViewModel.isShowing {
 				SlideMenu(isShowing: $menuViewModel.isShowing)

--- a/components/circle.swift
+++ b/components/circle.swift
@@ -285,47 +285,49 @@ struct ChainedSpring_Previews4: PreviewProvider {
 	}
 }
 
+/*
 struct Spring: View {
-	@Binding var isShowing: Bool
+        @Binding var isShowing: Bool
 
-	@State private var isRotating = false
-	@State private var isHidden = false
+        @State private var isRotating = false
+        @State private var isHidden = false
 
-	var body: some View {
-		VStack(spacing: 14){
+        var body: some View {
+                VStack(spacing: 14){
 
-			Rectangle() // top
-				.frame(width: 64, height: 10)
-				.cornerRadius(4)
-				.rotationEffect(.degrees(isRotating ? 48 : 0), anchor: .leading)
+                        Rectangle() // top
+                                .frame(width: 64, height: 10)
+                                .cornerRadius(4)
+                                .rotationEffect(.degrees(isRotating ? 48 : 0), anchor: .leading)
 
-			Rectangle() // middle
-				.frame(width: 64, height: 10)
-				.cornerRadius(4)
-				.scaleEffect(isHidden ? 0 : 1, anchor: isHidden ? .trailing: .leading)
-				.opacity(isHidden ? 0 : 1)
+                        Rectangle() // middle
+                                .frame(width: 64, height: 10)
+                                .cornerRadius(4)
+                                .scaleEffect(isHidden ? 0 : 1, anchor: isHidden ? .trailing: .leading)
+                                .opacity(isHidden ? 0 : 1)
 
-			Rectangle() // bottom
-				.frame(width: 64, height: 10)
-				.cornerRadius(4)
-				.rotationEffect(.degrees(isRotating ? -48 : 0), anchor: .leading)
-		}
-		.animation(.spring(), value: isShowing)
-		.onTapGesture {
-			withAnimation {
-				isShowing.toggle()
-			}
-		}
-		.onTapGesture {
-			withAnimation(.spring()){
-				isRotating.toggle()
-				isHidden.toggle()
-				
-			}
-		}
+                        Rectangle() // bottom
+                                .frame(width: 64, height: 10)
+                                .cornerRadius(4)
+                                .rotationEffect(.degrees(isRotating ? -48 : 0), anchor: .leading)
+                }
+                .animation(.spring(), value: isShowing)
+                .onTapGesture {
+                        withAnimation {
+                                isShowing.toggle()
+                        }
+                }
+                .onTapGesture {
+                        withAnimation(.spring()){
+                                isRotating.toggle()
+                                isHidden.toggle()
 
-	}
+                        }
+                }
+
+        }
 }
+*/
 
 //struct Spring_Previews: PreviewProvider {
 //	@StateObject private var menuViewModel = MenuViewModel()

--- a/views/ContentView.swift
+++ b/views/ContentView.swift
@@ -9,6 +9,7 @@ class Item: ObservableObject, Identifiable {
 @available(iOS 17.0, *)
 struct ContentView: View {
     @StateObject var dataManager = DataManager()
+    @StateObject private var menuViewModel = MenuViewModel()
 //    @StateObject var darkModeSettings = DataManager() // Use observed object for dark modem
 	@State private var items: [Item] = []
 
@@ -81,7 +82,11 @@ struct ContentView: View {
 //
                 }
 
+                SlideMenu(isShowing: $menuViewModel.isShowing)
+                    .environmentObject(dataManager)
+
             }
+            .animation(.default, value: menuViewModel.isShowing)
         }
     }
 }

--- a/views/MaterialListView.swift
+++ b/views/MaterialListView.swift
@@ -214,9 +214,7 @@ struct MaterialListView: View {
 	@EnvironmentObject var dataManager: DataManager
 
 
-	@State private var showMenu = true
-
-	@State private var selected = 4
+        @State private var selected = 4
 	func loadFromUserDefaults() {
 		if let savedData = UserDefaults.standard.data(forKey: "MaterialRequirements"),
 		   let decodedData = try? JSONDecoder().decode([String: [String: Int]].self, from: savedData)
@@ -271,8 +269,6 @@ struct MaterialListView: View {
 //			})
 			.navigationBarHidden(true)
 			.modifier(DarkModeLightModeBackground())
-//			SlideMenu( isShowing: $showMenu, materialRequirements: $materialRequirements)
-			SlideMenu( isShowing: $showMenu)
 
 		}
 		.id(dataManager.isDarkMode) 

--- a/views/OutletsView.swift
+++ b/views/OutletsView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @available(iOS 17.0, *)
 struct SingleGangView: View {
   @EnvironmentObject var dataManager: DataManager
-	@StateObject private var menuViewModel = MenuViewModel()
 
   var body: some View {
 	  
@@ -19,13 +18,14 @@ struct SingleGangView: View {
 		
 		ScrollView {
 			VStack {
-				Spring(isShowing: $menuViewModel.isShowing)
+                                // Spring menu button removed
+//                              Spring(isShowing: $menuViewModel.isShowing)
 
-				if menuViewModel.isShowing {
-					SlideMenu(isShowing: $menuViewModel.isShowing)
-						.frame(width: 300)
-						.transition(.move(edge: .leading))
-				}
+//                              if menuViewModel.isShowing {
+//                                      SlideMenu(isShowing: $menuViewModel.isShowing)
+//                                              .frame(width: 300)
+//                                              .transition(.move(edge: .leading))
+//                              }
 //
 //				Text("Outlets")
 //					.fontWeight(.black)
@@ -179,15 +179,15 @@ struct SingleGangView: View {
 		
 		.scrollDismissesKeyboard(.immediately)
 			sunview()
-		Spring(isShowing: $menuViewModel.isShowing)
+                // Spring menu button removed
+//              Spring(isShowing: $menuViewModel.isShowing)
 
-		if menuViewModel.isShowing {
-			SlideMenu(isShowing: $menuViewModel.isShowing)
-				.frame(width: 300)
-				.transition(.move(edge: .leading))
-		}
+//              if menuViewModel.isShowing {
+//                      SlideMenu(isShowing: $menuViewModel.isShowing)
+//                              .frame(width: 300)
+//                              .transition(.move(edge: .leading))
+//              }
 	}
-	.animation(.default, value: menuViewModel.isShowing)
 	.navigationBarHidden(true)
 	  Text("*Include GFCI and cut-in outlets in quantities.")
 		  .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary
- comment out Spring hamburger button implementation
- remove Spring menu button usage in outlets and demo views
- centralize SlideMenu display in `ContentView`
- tidy MaterialListView without local menu state

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68430b1bd51c832f96bd2479c5ca85d4