### PR TITLE
Fix counts for lights from detection

### DIFF
--- a/DataManager.swift
+++ b/DataManager.swift
@@ -15,68 +15,68 @@ import SwiftUI
 // Class managing global variables
 class DataManager: ObservableObject {
 	static let shared = DataManager()
-	@Published var bracketBoxDuplex: String = ""
-	@Published var gfci: String = ""
-	@Published var cutin: String = ""
-	@Published var surfaceMounted: String = ""
-	@Published var controlled: String = ""
-	@Published var scaled: String = ""
-	@Published var quadBracketBox: String = ""
-	@Published var quadGFCI: String = ""
-	@Published var quadCutIn: String = ""
-	@Published var quadSurfaceMounted: String = ""
-	@Published var quadControlled: String = ""
+        @Published var bracketBoxDuplex: String = "0"
+        @Published var gfci: String = "0"
+        @Published var cutin: String = "0"
+        @Published var surfaceMounted: String = "0"
+        @Published var controlled: String = "0"
+        @Published var scaled: String = "0"
+        @Published var quadBracketBox: String = "0"
+        @Published var quadGFCI: String = "0"
+        @Published var quadCutIn: String = "0"
+        @Published var quadSurfaceMounted: String = "0"
+        @Published var quadControlled: String = "0"
 	@Published var employeeNames: [String] = []
 	@Published var boxTotal: String = ""
 	@Published var timeSelector: Int = 0
 	@Published var employeeIDs: [String: String] = [:]
 
-	@Published var wire3FurnitureFeed: String = ""
-	@Published var wire2FurnitureFeed: String = ""
-	@Published var bracketBoxData: String = ""
-	@Published var cutInData: String = ""
+        @Published var wire3FurnitureFeed: String = "0"
+        @Published var wire2FurnitureFeed: String = "0"
+        @Published var bracketBoxData: String = "0"
+        @Published var cutInData: String = "0"
 	
-	@Published var homerunLength: String = "" {
+        @Published var homerunLength: String = "0" {
 		didSet {
 			calculateMCTotal()
 		}
 	}
 	
-	@Published var homerunQuantity: String = "" {
+        @Published var homerunQuantity: String = "0" {
 		didSet {
 			calculateMCTotal()
 		}
 	}
-	@Published var mcTotal: String = ""
+        @Published var mcTotal: String = "0"
 	
-	@Published var lineVoltageDimmingSwitch: String = ""
-	@Published var lineVoltageDimmingCutin: String = ""
+        @Published var lineVoltageDimmingSwitch: String = "0"
+        @Published var lineVoltageDimmingCutin: String = "0"
 	
-	@Published var lvCat5Switch: String = ""
-	@Published var lvCat5Cutin: String = ""
+        @Published var lvCat5Switch: String = "0"
+        @Published var lvCat5Cutin: String = "0"
 	
-	@Published var lineVoltageSwitch: String = ""
-	@Published var lineVoltageCutIn: String = ""
+        @Published var lineVoltageSwitch: String = "0"
+        @Published var lineVoltageCutIn: String = "0"
 	
-	@Published var twoGangSwitch: String = ""
-	@Published var twoGangCutinSwitch: String = ""
-	@Published var lvTwoGangSwitch: String = ""
-	@Published var lvTwoGangCutinSwitch: String = ""
+        @Published var twoGangSwitch: String = "0"
+        @Published var twoGangCutinSwitch: String = "0"
+        @Published var lvTwoGangSwitch: String = "0"
+        @Published var lvTwoGangCutinSwitch: String = "0"
 
-	@Published var inFloorDevice: String = ""
-	@Published var in6FloorDevice: String = ""
-	@Published var singlePole277V40AInstahot: String = ""
-	@Published var pole208V40AInstahot: String = ""
-	@Published var singlePole277V30AInstahot: String = ""
+        @Published var inFloorDevice: String = "0"
+        @Published var in6FloorDevice: String = "0"
+        @Published var singlePole277V40AInstahot: String = "0"
+        @Published var pole208V40AInstahot: String = "0"
+        @Published var singlePole277V30AInstahot: String = "0"
 	
-	@Published var twoXtwo: String = ""
-	@Published var threeWaySwitch: String = ""
-	@Published var ceilingMotionSensor: String = ""
-	@Published var EMG2x2: String = ""
-	@Published var exitSign: String = ""
-	@Published var exitSignBox: String = ""
+        @Published var twoXtwo: String = "0"
+        @Published var threeWaySwitch: String = "0"
+        @Published var ceilingMotionSensor: String = "0"
+        @Published var EMG2x2: String = "0"
+        @Published var exitSign: String = "0"
+        @Published var exitSignBox: String = "0"
 
-	@Published var pendantLight: String = ""
+        @Published var pendantLight: String = "0"
 
 
 

--- a/views/DeviceFinderAPI.swift
+++ b/views/DeviceFinderAPI.swift
@@ -452,24 +452,66 @@ Spacer()
                                     Text(dataManager.gfci)
                                 }
                             }
-                            if Int(dataManager.wire3FurnitureFeed) ?? 0 > 0 {
-                                HStack {
-                                    Text("3 Wire Furniture Feed- ")
-                                    Spacer()
-                                    Text(dataManager.wire3FurnitureFeed)
-                                }
-                            }
-                            if Int(dataManager.bracketBoxData) ?? 0 > 0 {
-                                HStack {
-                                    Text("Data(Bracket Box)- ")
-                                    Spacer()
-                                    Text(dataManager.bracketBoxData)
-                                }
-                            }
-                        }
-                        Button(action: {
-                            self.showingSheet = false
-                            navigateToMaterialView = true
+                if Int(dataManager.wire3FurnitureFeed) ?? 0 > 0 {
+                    HStack {
+                        Text("3 Wire Furniture Feed- ")
+                        Spacer()
+                        Text(dataManager.wire3FurnitureFeed)
+                    }
+                }
+                if Int(dataManager.bracketBoxData) ?? 0 > 0 {
+                    HStack {
+                        Text("Data(Bracket Box)- ")
+                        Spacer()
+                        Text(dataManager.bracketBoxData)
+                    }
+                }
+                if Int(dataManager.twoXtwo) ?? 0 > 0 {
+                    HStack {
+                        Text("2x2, 2x4, Linear- ")
+                        Spacer()
+                        Text(dataManager.twoXtwo)
+                    }
+                }
+                if Int(dataManager.EMG2x2) ?? 0 > 0 {
+                    HStack {
+                        Text("EMG 2x2/2x4/Canlight- ")
+                        Spacer()
+                        Text(dataManager.EMG2x2)
+                    }
+                }
+                if Int(dataManager.ceilingMotionSensor) ?? 0 > 0 {
+                    HStack {
+                        Text("Ceiling Motion Sensor- ")
+                        Spacer()
+                        Text(dataManager.ceilingMotionSensor)
+                    }
+                }
+                if Int(dataManager.exitSign) ?? 0 > 0 {
+                    HStack {
+                        Text("Exit Sign Surface- ")
+                        Spacer()
+                        Text(dataManager.exitSign)
+                    }
+                }
+                if Int(dataManager.exitSignBox) ?? 0 > 0 {
+                    HStack {
+                        Text("Exit Sign Box Mount- ")
+                        Spacer()
+                        Text(dataManager.exitSignBox)
+                    }
+                }
+                if Int(dataManager.pendantLight) ?? 0 > 0 {
+                    HStack {
+                        Text("Pendant Light- ")
+                        Spacer()
+                        Text(dataManager.pendantLight)
+                    }
+                }
+            }
+            Button(action: {
+                self.showingSheet = false
+                navigateToMaterialView = true
 
                         }) {
                             Text("Import")
@@ -641,20 +683,41 @@ Spacer()
 //	15: 'Occupancy Dimmer Switch- lineVoltageSwitch',
     func loadMaterials() {
         print("METHOD loadMaterials")
-		var lineVoltageSwitchTotal = 0  // Temporary variable to accumulate counts
+        var lineVoltageSwitchTotal = 0  // Temporary variable to accumulate counts
+        var standardLightTotal = 0       // 2x2, 2x4, Linear
+        var emgLightTotal = 0            // EMG 2x2, EMG 2x4, EMG Canlight
+        var exitSignSurfaceTotal = 0
+        var exitSignBoxTotal = 0
+        var pendantLightTotal = 0
+        var threeWaySwitchTotal = 0
+        var ceilingMotionSensorTotal = 0
 
         for (device, count) in classCounts {
             if count != 0 {
                 switch device {
-				case "Line Voltage Switch":
-					lineVoltageSwitchTotal += count // Add count to the total
-					print("Line Voltage Switch count: \(count)")
-				case "Low Voltage Controlls Switch":
-					dataManager.lvCat5Switch = String(count)
-					print("Low Voltage Controlls Switch count: \(dataManager.lvCat5Switch)")
-				case "Occupency Dimmer Switch":
-					lineVoltageSwitchTotal += count // Add count to the total
-					print("Occupency Dimmer Switch count: \(count)")
+                case "Line Voltage Switch":
+                    lineVoltageSwitchTotal += count
+                    print("Line Voltage Switch count: \(count)")
+                case "Low Voltage Controlls Switch":
+                    dataManager.lvCat5Switch = String(count)
+                    print("Low Voltage Controlls Switch count: \(dataManager.lvCat5Switch)")
+                case "Occupency Dimmer Switch":
+                    lineVoltageSwitchTotal += count
+                    print("Occupency Dimmer Switch count: \(count)")
+                case "3-way Switch":
+                    threeWaySwitchTotal += count
+                case "Ceiling Mounted Motion Sensor", "Occupancy Sensor":
+                    ceilingMotionSensorTotal += count
+                case "2x2", "2x4", "Linear", "Canlight", "Demo 2x2", "Demo 2x4", "Demo Canlight":
+                    standardLightTotal += count
+                case "EMG 2x2", "EMG 2x4", "EMG Canlight":
+                    emgLightTotal += count
+                case "Exit Sign":
+                    exitSignSurfaceTotal += count
+                case "Exit Sign- Box Mount":
+                    exitSignBoxTotal += count
+                case "Pendant Light":
+                    pendantLightTotal += count
                 case "Data Box":
                     dataManager.bracketBoxData = String(count)
                     print(dataManager.bracketBoxData)
@@ -678,9 +741,18 @@ Spacer()
                 }
             }
         }
-		// Set the total count for Line Voltage Switch in the dataManager
-		dataManager.lineVoltageSwitch = String(lineVoltageSwitchTotal)
-		print("Total Line Voltage Switch count: \(dataManager.lineVoltageSwitch)")
+
+        // Set totals for aggregated categories
+        dataManager.lineVoltageSwitch = String(lineVoltageSwitchTotal)
+        dataManager.twoXtwo = String(standardLightTotal)
+        dataManager.EMG2x2 = String(emgLightTotal)
+        dataManager.exitSign = String(exitSignSurfaceTotal)
+        dataManager.exitSignBox = String(exitSignBoxTotal)
+        dataManager.pendantLight = String(pendantLightTotal)
+        dataManager.threeWaySwitch = String(threeWaySwitchTotal)
+        dataManager.ceilingMotionSensor = String(ceilingMotionSensorTotal)
+
+        print("Total Line Voltage Switch count: \(dataManager.lineVoltageSwitch)")
     }
 
 	func uploadImage(completion: @escaping (Bool) -> Void) {
@@ -878,6 +950,9 @@ Spacer()
         DispatchQueue.main.async {
             self.classCounts = classCounts
             print("!!!!!!\(self.classCounts)")
+            // Immediately populate DataManager with the latest counts so the
+            // import sheet reflects all detected devices
+            self.loadMaterials()
         }
         return newImage
     }

--- a/views/OutletsView.swift
+++ b/views/OutletsView.swift
@@ -877,8 +877,14 @@ struct OutletCalculatorView: View {
 									"4in Floor Device": dataManager.in6FloorDevice,
 									"Single-Pole 277V 40A Instahot": dataManager.singlePole277V40AInstahot,
 									"2-Pole 208V 40A Instahot": dataManager.pole208V40AInstahot,
-									"Single-Pole 277V 30A Instahot": dataManager.singlePole277V30AInstahot,
-								]))
+                                                                        "Single-Pole 277V 30A Instahot": dataManager.singlePole277V30AInstahot,
+                                                                        "2x2, 2x4, Linear": dataManager.twoXtwo,
+                                                                        "Ceiling Motion Motion Sensor": dataManager.ceilingMotionSensor,
+                                                                        "EMG 2x2, EMG 2x4, EMG Linear": dataManager.EMG2x2,
+                                                                        "Exit Sign- Surface Mount": dataManager.exitSign,
+                                                                        "Exit Sign- Box Mount": dataManager.exitSignBox,
+                                                                        "Pendant Light": dataManager.pendantLight,
+                                                                ]))
 						
 					}
 					.padding()


### PR DESCRIPTION
## Summary
- aggregate counts for additional devices in `loadMaterials`
- show counts in import sheet
- forward light-related counts to materials calculator
- initialize DataManager counters to 0
- populate counts right after detection to keep values in sync

## Testing
- `swiftc --version`


------
https://chatgpt.com/codex/tasks/task_e_68430ef8b7b0832fb9521f549145c5c5